### PR TITLE
feat: allow init without RPC

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm run build
+      - run: npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,3 +13,4 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm run lint
+      - run: npm run typescript

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "rm -rf lib && tsc -p tsconfig.build.json",
+    "typescript": "tsc",
     "lint": "eslint src --ext .ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "url": "https://github.com/curvefi/curve-stablecoin-js/issues"
   },
   "scripts": {
-    "build": "rm -rf lib && tsc -p tsconfig.build.json"
+    "build": "rm -rf lib && tsc -p tsconfig.build.json",
+    "lint": "eslint src --ext .ts"
   },
   "devDependencies": {
     "@types/chai": "^4.2.18",

--- a/src/crvusd.ts
+++ b/src/crvusd.ts
@@ -18,8 +18,8 @@ import { extractDecimals } from "./constants/utils";
 
 class Crvusd implements Icrvusd {
     address: string;
-    provider: ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider;
-    multicallProvider: MulticallProvider;
+    provider: ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider | null;
+    multicallProvider: MulticallProvider | null;
     signer: ethers.Signer | null;
     signerAddress: string;
     chainId: number;
@@ -39,13 +39,10 @@ class Crvusd implements Icrvusd {
 
     constructor() {
         this.address = COINS.crvusd.toLowerCase();
-        // @ts-ignore
         this.provider = null;
-        // @ts-ignore
         this.signer = null;
         this.signerAddress = "";
         this.chainId = 0;
-        // @ts-ignore
         this.multicallProvider = null;
         this.contracts = {};
         this.feeData = {}
@@ -72,9 +69,7 @@ class Crvusd implements Icrvusd {
         providerSettings?: { url?: string, privateKey?: string } | { externalProvider: ethers.providers.ExternalProvider } | { network?: Networkish, apiKey?: string },
         options: { gasPrice?: number, maxFeePerGas?: number, maxPriorityFeePerGas?: number, chainId?: number } = {} // gasPrice in Gwei
     ): Promise<void> {
-        // @ts-ignore
         this.provider = null;
-        // @ts-ignore
         this.signer = null;
         this.signerAddress = "";
         this.chainId = 0;
@@ -228,6 +223,7 @@ class Crvusd implements Icrvusd {
     }
 
     setContract(address: string, abi: any): void {
+        if (!this.provider) throw Error('Cannot set contract without provider')
         this.contracts[address] = {
             contract: new Contract(address, abi, this.signer || this.provider),
             multicallContract: new MulticallContract(address, abi),
@@ -249,6 +245,7 @@ class Crvusd implements Icrvusd {
     }
 
     async updateFeeData(): Promise<void> {
+        if (!this.provider) throw Error('Cannot update fee data without provider')
         const feeData = await this.provider.getFeeData();
         if (feeData.maxFeePerGas === null || feeData.maxPriorityFeePerGas === null) {
             delete this.options.maxFeePerGas;

--- a/src/crvusd.ts
+++ b/src/crvusd.ts
@@ -23,7 +23,7 @@ class Crvusd implements Icrvusd {
     signer: ethers.Signer | null;
     signerAddress: string;
     chainId: number;
-    contracts: { [index: string]: { contract: Contract, multicallContract: MulticallContract } };
+    contracts: { [index: string]: { contract: Contract, multicallContract: MulticallContract } } | null;
     feeData: { gasPrice?: number, maxFeePerGas?: number, maxPriorityFeePerGas?: number };
     constantOptions: { gasLimit: number };
     options: { gasPrice?: number | ethers.BigNumber, maxFeePerGas?: number | ethers.BigNumber, maxPriorityFeePerGas?: number | ethers.BigNumber };
@@ -44,7 +44,7 @@ class Crvusd implements Icrvusd {
         this.signerAddress = "";
         this.chainId = 0;
         this.multicallProvider = null;
-        this.contracts = {};
+        this.contracts = null;
         this.feeData = {}
         this.constantOptions = { gasLimit: 12000000 }
         this.options = {};
@@ -75,12 +75,12 @@ class Crvusd implements Icrvusd {
         this.chainId = 0;
         // @ts-ignore
         this.multicallProvider = null;
-        this.contracts = {};
         this.feeData = {}
         this.constantOptions = { gasLimit: 12000000 }
         this.options = {};
 
         if (!providerType) return;
+        this.contracts = {};
 
         // JsonRpc provider
         if (providerType.toLowerCase() === 'JsonRpc'.toLowerCase()) {
@@ -223,7 +223,7 @@ class Crvusd implements Icrvusd {
     }
 
     setContract(address: string, abi: any): void {
-        if (!this.provider) throw Error('Cannot set contract without provider')
+        if (!this.provider || !this.contracts) throw Error('Cannot set contract without provider')
         this.contracts[address] = {
             contract: new Contract(address, abi, this.signer || this.provider),
             multicallContract: new MulticallContract(address, abi),

--- a/src/crvusd.ts
+++ b/src/crvusd.ts
@@ -68,8 +68,8 @@ class Crvusd implements Icrvusd {
     }
 
     async init(
-        providerType: 'JsonRpc' | 'Web3' | 'Infura' | 'Alchemy',
-        providerSettings: { url?: string, privateKey?: string } | { externalProvider: ethers.providers.ExternalProvider } | { network?: Networkish, apiKey?: string },
+        providerType?: 'JsonRpc' | 'Web3' | 'Infura' | 'Alchemy',
+        providerSettings?: { url?: string, privateKey?: string } | { externalProvider: ethers.providers.ExternalProvider } | { network?: Networkish, apiKey?: string },
         options: { gasPrice?: number, maxFeePerGas?: number, maxPriorityFeePerGas?: number, chainId?: number } = {} // gasPrice in Gwei
     ): Promise<void> {
         // @ts-ignore
@@ -84,6 +84,8 @@ class Crvusd implements Icrvusd {
         this.feeData = {}
         this.constantOptions = { gasLimit: 12000000 }
         this.options = {};
+
+        if (!providerType) return;
 
         // JsonRpc provider
         if (providerType.toLowerCase() === 'JsonRpc'.toLowerCase()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,8 @@ import {
 
 
 async function init (
-    providerType: 'JsonRpc' | 'Web3' | 'Infura' | 'Alchemy',
-    providerSettings: { url?: string, privateKey?: string } | { externalProvider: ethers.providers.ExternalProvider } | { network?: Networkish, apiKey?: string },
+    providerType?: 'JsonRpc' | 'Web3' | 'Infura' | 'Alchemy',
+    providerSettings?: { url?: string, privateKey?: string } | { externalProvider: ethers.providers.ExternalProvider } | { network?: Networkish, apiKey?: string },
     options: { gasPrice?: number, maxFeePerGas?: number, maxPriorityFeePerGas?: number, chainId?: number } = {}
 ): Promise<void> {
     await _crvusd.init(providerType, providerSettings, options);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -27,7 +27,7 @@ export interface Icrvusd {
     multicallProvider: MulticallProvider | null,
     signer: ethers.Signer | null,
     signerAddress: string,
-    contracts: { [index: string]: { contract: Contract, multicallContract: MulticallContract } },
+    contracts: { [index: string]: { contract: Contract, multicallContract: MulticallContract } } | null,
     feeData: { gasPrice?: number, maxFeePerGas?: number, maxPriorityFeePerGas?: number },
     constantOptions: { gasLimit: number },
     options: { gasPrice?: number | ethers.BigNumber, maxFeePerGas?: number | ethers.BigNumber, maxPriorityFeePerGas?: number | ethers.BigNumber },

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,8 +23,8 @@ export interface ILlamma {
 }
 
 export interface Icrvusd {
-    provider: ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider,
-    multicallProvider: MulticallProvider,
+    provider: ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider | null,
+    multicallProvider: MulticallProvider | null,
     signer: ethers.Signer | null,
     signerAddress: string,
     contracts: { [index: string]: { contract: Contract, multicallContract: MulticallContract } },

--- a/src/llammas/LlammaTemplate.ts
+++ b/src/llammas/LlammaTemplate.ts
@@ -218,6 +218,8 @@ export class LlammaTemplate {
         liquidation_discount: string, // %
         loan_discount: string, // %
     }> => {
+        if (!crvusd.multicallProvider) throw Error('Cannot get parameters without provider')
+
         const llammaContract = crvusd.contracts[this.address].multicallContract;
         const controllerContract = crvusd.contracts[this.controller].multicallContract;
         const monetaryPolicyContract = crvusd.contracts[this.monetaryPolicy].multicallContract;
@@ -247,6 +249,8 @@ export class LlammaTemplate {
     });
 
     private async statsBalances(): Promise<[string, string]> {
+        if (!crvusd.multicallProvider) throw Error('Cannot get balances without provider')
+
         const crvusdContract = crvusd.contracts[crvusd.address].multicallContract;
         const collateralContract = crvusd.contracts[isEth(this.collateral) ? crvusd.constants.WETH : this.collateral].multicallContract;
         const contract = crvusd.contracts[this.address].multicallContract;
@@ -265,6 +269,8 @@ export class LlammaTemplate {
     }
 
     private statsMaxMinBands = memoize(async (): Promise<[number, number]> => {
+        if (!crvusd.multicallProvider) throw Error('Cannot get max and min bands without provider')
+
         const llammaContract = crvusd.contracts[this.address].multicallContract;
 
         const calls1 = [
@@ -295,6 +301,8 @@ export class LlammaTemplate {
     }
 
     private async statsBandBalances(n: number): Promise<{ stablecoin: string, collateral: string }> {
+        if (!crvusd.multicallProvider) throw Error('Cannot get band balances without provider')
+
         const llammaContract = crvusd.contracts[this.address].multicallContract;
         const calls = [];
         calls.push(llammaContract.bands_x(n), llammaContract.bands_y(n));
@@ -308,6 +316,8 @@ export class LlammaTemplate {
     }
 
     private async statsBandsBalances(): Promise<{ [index: number]: { stablecoin: string, collateral: string } }> {
+        if (!crvusd.multicallProvider) throw Error('Cannot get bands balances without provider')
+
         const [max_band, min_band]: number[] = await this.statsMaxMinBands();
 
         const llammaContract = crvusd.contracts[this.address].multicallContract;
@@ -334,6 +344,8 @@ export class LlammaTemplate {
     }
 
     private statsTotalSupply = memoize(async (): Promise<string> => {
+        if (!crvusd.multicallProvider) throw Error('Cannot get total supply without provider')
+
         const controllerContract = crvusd.contracts[this.controller].multicallContract;
         const calls = [controllerContract.minted(), controllerContract.redeemed()]
         const [_minted, _redeemed]: ethers.BigNumber[] = await crvusd.multicallProvider.all(calls);
@@ -356,6 +368,8 @@ export class LlammaTemplate {
     });
 
     private statsTotalStablecoin = memoize(async (): Promise<string> => {
+        if (!crvusd.multicallProvider) throw Error('Cannot get total stablecoin without provider')
+
         const stablecoinContract = crvusd.contracts[crvusd.address].multicallContract;
         const ammContract = crvusd.contracts[this.address].multicallContract;
 
@@ -372,6 +386,8 @@ export class LlammaTemplate {
     });
 
     private statsTotalCollateral = memoize(async (): Promise<string> => {
+        if (!crvusd.multicallProvider) throw Error('Cannot get total collateral without provider')
+
         const collateralContract = crvusd.contracts[isEth(this.collateral) ? crvusd.constants.WETH : this.collateral].multicallContract;
         const ammContract = crvusd.contracts[this.address].multicallContract;
 
@@ -388,6 +404,8 @@ export class LlammaTemplate {
     });
 
     private statsCapAndAvailable = memoize(async (): Promise<{ "cap": string, "available": string }> => {
+        if (!crvusd.multicallProvider) throw Error('Cannot get cap and available without provider')
+
         const factoryContract = crvusd.contracts[crvusd.constants.FACTORY].multicallContract;
         const crvusdContract = crvusd.contracts[crvusd.address].multicallContract;
 
@@ -594,6 +612,8 @@ export class LlammaTemplate {
     }
 
     public createLoanMaxRecvAllRanges = memoize(async (collateral: number | string): Promise<{ [index: number]: string }> => {
+        if (!crvusd.multicallProvider) throw Error('Cannot get max borrowable without provider')
+
         const _collateral = parseUnits(collateral, this.collateralDecimals);
 
         const calls = [];
@@ -629,6 +649,8 @@ export class LlammaTemplate {
     }
 
     private async _calcN1AllRanges(_collateral: ethers.BigNumber, _debt: ethers.BigNumber, maxN: number): Promise<ethers.BigNumber[]> {
+        if (!crvusd.multicallProvider) throw Error('Cannot get max borrowable without provider')
+
         const calls = [];
         for (let N = this.minBands; N <= maxN; N++) {
             calls.push(crvusd.contracts[this.controller].multicallContract.calculate_debt_n1(_collateral, _debt, N));
@@ -637,6 +659,8 @@ export class LlammaTemplate {
     }
 
     private async _getPrices(_n2: ethers.BigNumber, _n1: ethers.BigNumber): Promise<string[]> {
+        if (!crvusd.multicallProvider) throw Error('Cannot get prices without provider')
+
         const contract = crvusd.contracts[this.address].multicallContract;
         return (await crvusd.multicallProvider.all([
             contract.p_oracle_down(_n2),
@@ -1321,6 +1345,8 @@ export class LlammaTemplate {
 
     private async leverageCreateLoanMaxRecv(collateral: number | string, range: number):
         Promise<{ maxBorrowable: string, maxCollateral: string, leverage: string, routeIdx: number }> {
+        if (!crvusd.multicallProvider) throw Error('Cannot get max borrowable and collateral without provider')
+
         this._checkLeverageZap();
         this._checkRange(range);
         const _collateral = parseUnits(collateral, this.collateralDecimals);
@@ -1345,6 +1371,8 @@ export class LlammaTemplate {
 
     private leverageCreateLoanMaxRecvAllRanges = memoize(async (collateral: number | string):
         Promise<IDict<{ maxBorrowable: string, maxCollateral: string, leverage: string, routeIdx: number }>> => {
+        if (!crvusd.multicallProvider) throw Error('Cannot get max borrowable and collateral without provider')
+
         this._checkLeverageZap();
         const _collateral = parseUnits(collateral, this.collateralDecimals);
 
@@ -1381,6 +1409,8 @@ export class LlammaTemplate {
 
     private _leverageCreateLoanMaxRecvAllRanges2 = memoize(async (collateral: number | string, routeIdx: number):
         Promise<IDict<{ maxBorrowable: string, maxCollateral: string, leverage: string}>> => {
+        if (!crvusd.multicallProvider) throw Error('Cannot get max borrowable and collateral without provider')
+
         const _collateral = parseUnits(collateral, this.collateralDecimals);
 
         const calls = [];
@@ -1409,6 +1439,8 @@ export class LlammaTemplate {
 
     private _leverageCreateLoanCollateral = memoize(async (userCollateral: number | string, debt: number | string):
     Promise<{ _collateral: ethers.BigNumber, routeIdx: number }> => {
+        if (!crvusd.multicallProvider) throw Error('Cannot get collateral without provider')
+
         const _userCollateral = parseUnits(userCollateral, this.collateralDecimals);
         const _debt = parseUnits(debt);
         const calls = [];
@@ -1465,6 +1497,8 @@ export class LlammaTemplate {
     }
 
     private async _leverageCalcN1AllRanges(collateral: number | string, debt: number | string, maxN: number): Promise<ethers.BigNumber[]> {
+        if (!crvusd.multicallProvider) throw Error('Cannot get max borrowable without provider')
+
         const routeIdx = await this._getRouteIdx(collateral, debt);
         const _collateral = parseUnits(collateral, this.collateralDecimals);
         const _debt = parseUnits(debt);
@@ -1626,6 +1660,8 @@ export class LlammaTemplate {
     }
 
     private deleverageRepayStablecoins = memoize( async (collateral: number | string): Promise<{ stablecoins: string, routeIdx: number }> => {
+        if (!crvusd.multicallProvider) throw Error('Cannot get stablecoins without provider')
+
         this._checkDeleverageZap();
         const _collateral = parseUnits(collateral, this.collateralDecimals);
         const calls = [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,6 +85,8 @@ export const _getCoinDecimals = (coinAddresses: string[]): number[] => {
 // --- BALANCES ---
 
 export const _getBalances = async (coinAddresses: string[], address = ""): Promise<ethers.BigNumber[]> => {
+    if (!crvusd.provider || !crvusd.multicallProvider) throw Error('Cannot get balances without provider')
+
     address = _getAddress(address);
     const _coinAddresses = [...coinAddresses];
     const ethIndex = getEthIndex(_coinAddresses);
@@ -117,6 +119,7 @@ export const getBalances = async (coins: string[], address = ""): Promise<string
 // --- ALLOWANCE ---
 
 export const _getAllowance = async (coins: string[], address: string, spender: string): Promise<ethers.BigNumber[]> => {
+    if (!crvusd.multicallProvider) throw Error('Cannot get allowance without provider')
     const _coins = [...coins]
     const ethIndex = getEthIndex(_coins);
     if (ethIndex !== -1) {
@@ -267,6 +270,8 @@ export const getUsdRate = async (coin: string): Promise<number> => {
 }
 
 export const totalSupply = async (): Promise<{ total: string, minted: string, pegKeepersDebt: string }> => {
+    if (!crvusd.multicallProvider) throw Error('Cannot get total supply without provider')
+
     const calls = [];
     for (const llammaId of crvusd.getLlammaList()) {
         const controllerAddress = crvusd.constants.LLAMMAS[llammaId].controller_address;


### PR DESCRIPTION
Let me be clear: I do not like throwing exceptions. Ideally we should make the invalid states unreachable. However, given the existing code base, throwing good errors seems like the only feasible way.

- CurveStableCoinJS currently requires a web3 provider to be initialized
- However, we might not always have a RPC connection
- This PR allows users to retrieve (part of) the data without requiring a RPC connection
- However, it will raise exceptions whenever a function that requires RPC is called

This PR is similar to https://github.com/curvefi/curve-js/pull/394 and https://github.com/curvefi/curve-lending-js/pull/34